### PR TITLE
feat: automate test static file generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: "1.23"
 
       - name: Build
-        run: go build -v ./...
+        run: make build
 
       - name: Test
-        run: go test -v ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: build
+build:
+	go build -v ./...
+
+.PHONY: test
+test:
+	go test -v ./...
+
+.PHONY: test-static-files
+test-static-files:
+	GENERATE_STATIC_FILES=true go test -v ./...

--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ fern-junit-client send -u "http://localhost:8080" -p "MyService" -f "tests/*.xml
 * [Fern UI](https://github.com/guidewire-oss/fern-ui)
 * [Fern Reporter](https://github.com/guidewire-oss/fern-reporter)
 * [Fern Ginkgo Client](https://github.com/guidewire-oss/fern-ginkgo-client)
+
+## Development
+
+### Executing Tests
+
+To execute the tests, run `make test`
+
+### Generating Test Static Files
+
+To generate the static files used in the tests, run `make test-static-files`

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -3,17 +3,21 @@ package client
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"testing"
 
 	"github.com/guidewire-oss/fern-junit-client/pkg/models/fern"
 	"github.com/guidewire-oss/fern-junit-client/pkg/models/junit"
 )
 
 const (
-	testProjectName     = "TestProject"
+	testProjectName = "TestProject"
+	exampleTags     = "test,tagtest,9=-+_"
+
 	nonExistentFilePath = "this_file_does_not_exist"
 
 	reportsCombinedPattern = "../../test/static/*.xml"
@@ -23,8 +27,6 @@ const (
 	fernTestRunCombinedPath = "../../test/static/fern_test_run_combined.json"
 	fernTestRunFailedPath   = "../../test/static/fern_test_run_failed.json"
 	fernTestRunPassedPath   = "../../test/static/fern_test_run_passed.json"
-
-	exampleTags = "test,tagtest,9=-+_"
 )
 
 var (
@@ -87,4 +89,50 @@ func init() {
 	} else if err := json.Unmarshal(bytes, &fernTestRunPassed); err != nil {
 		panic(err)
 	}
+}
+
+func TestGenerateStaticJsonFiles(t *testing.T) {
+	// Skip on normal test execution
+	if os.Getenv("GENERATE_STATIC_FILES") != "true" {
+		t.SkipNow()
+	}
+	// Generate static JSON files used in tests
+	generateFernTestRunJson := func(testCase, filePattern, outputFilename string) {
+		// Create mock Fern reporter that writes JSON payload to a file
+		mockFernReporter := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+			testRun := &fern.TestRun{}
+			if data, err := io.ReadAll(r.Body); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+			} else if err := json.Unmarshal(data, testRun); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+			} else {
+				w.WriteHeader(http.StatusOK)
+				// Format JSON
+				formattedJson, err := json.MarshalIndent(testRun, "", "  ")
+				if err != nil {
+					panic(err)
+				}
+				// Save JSON
+				f, err := os.Create(outputFilename)
+				if err != nil {
+					panic(err)
+				}
+				defer f.Close()
+				_, err = f.Write(formattedJson)
+				if err != nil {
+					panic(err)
+				}
+			}
+		}))
+		defer mockFernReporter.Close()
+		// Run SendReports with input
+		if err := SendReports(mockFernReporter.URL, testProjectName, filePattern, exampleTags, true); err != nil {
+			panic(fmt.Errorf("failed to generate Fern test run JSON for '%s' test case (%s): %w", testCase, filePattern, err))
+		}
+	}
+	// Call generateFernTestRunJson for each test case
+	generateFernTestRunJson("reports combined", reportsCombinedPattern, fernTestRunCombinedPath)
+	generateFernTestRunJson("failed report", reportFailedPath, fernTestRunFailedPath)
+	generateFernTestRunJson("passed report", reportPassedPath, fernTestRunPassedPath)
 }

--- a/test/static/fern_test_run_combined.json
+++ b/test/static/fern_test_run_combined.json
@@ -1,7 +1,7 @@
 {
   "id": 0,
-  "test_project_name": "Fern JUnit Client Test",
-  "test_seed": 0,
+  "test_project_name": "TestProject",
+  "test_seed": 288470000,
   "start_time": "2024-11-01T18:23:56Z",
   "end_time": "2024-11-01T18:23:56.12Z",
   "suite_runs": [

--- a/test/static/fern_test_run_failed.json
+++ b/test/static/fern_test_run_failed.json
@@ -1,7 +1,7 @@
 {
   "id": 0,
-  "test_project_name": "Fern JUnit Client Test",
-  "test_seed": 0,
+  "test_project_name": "TestProject",
+  "test_seed": 291359000,
   "start_time": "2024-11-01T18:23:56Z",
   "end_time": "2024-11-01T18:23:56.12Z",
   "suite_runs": [

--- a/test/static/fern_test_run_passed.json
+++ b/test/static/fern_test_run_passed.json
@@ -1,7 +1,7 @@
 {
   "id": 0,
-  "test_project_name": "Fern JUnit Client Test",
-  "test_seed": 0,
+  "test_project_name": "TestProject",
+  "test_seed": 293550000,
   "start_time": "2024-11-01T18:23:56Z",
   "end_time": "2024-11-01T18:23:56.12Z",
   "suite_runs": [


### PR DESCRIPTION
This addresses https://github.com/guidewire-oss/fern-junit-client/issues/13 with the intention of making it super easy to update the tests when we add new features.
Now, to re-generate the static JSON files used in the tests, you just have to run `make test-static-files`.