### PR TITLE
feat: add auth and addtional requested changes #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Fern JUnit Client
 
-A CLI that can read JUnit test reports and send them to a Fern Reporter instance in a format it understands
+A CLI that can read JUnit test reports and send them to a Fern Platform instance in a format it understands
 
 ## Introduction
 
-If you don't know what Fern is, [check it out here!](https://github.com/guidewire-oss/fern-reporter)
+If you don't know what Fern is, [check it out here!](https://github.com/guidewire-oss/fern-platform)
 
 ## Install
 
@@ -15,7 +15,7 @@ go install github.com/guidewire-oss/fern-junit-client@latest
 ```
 
 
-## Registering Application with Fern-Reporter
+## Registering Application with Fern Platform
 ```bash
 curl -L -X POST http://localhost:8080/api/project \
   -H "Content-Type: application/json" \
@@ -23,7 +23,7 @@ curl -L -X POST http://localhost:8080/api/project \
     "name": "First Projects",
     "team_name": "my team",
     "comment": "This is the test project"
-  }' 
+  }'
 ```
 
 Sample Response:
@@ -54,10 +54,84 @@ fern-junit-client send -u "http://localhost:8080" -p "77b34e74-5631-5a71-b8ce-97
 fern-junit-client send -u "http://localhost:8080" -p "77b34e74-5631-5a71-b8ce-97b9d6bab10a" -f "tests/*.xml"
 ```
 
+### Configuration
+
+The fern-junit-client can be configured using environment variables:
+
+#### API Endpoint Configuration
+
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `FERN_API_ENDPOINT_PATH` | Override the API endpoint path | `api/v1/test-runs` |
+
+Example:
+```sh
+# Use a custom API endpoint path
+export FERN_API_ENDPOINT_PATH="api/v2/test-results"
+fern-junit-client send -u "http://localhost:8080" -p "77b34e74-5631-5a71-b8ce-97b9d6bab10a" -f "report.xml"
+```
+
+### OAuth Authentication
+
+The fern-junit-client supports OAuth 2.0 authentication using the client credentials grant type. This allows the client to authenticate with the Fern backend using OAuth tokens.
+
+#### OAuth Configuration
+
+OAuth authentication is configured via environment variables:
+
+| Environment Variable | Description | Required |
+|---------------------|-------------|----------|
+| `AUTH_URL` | The OAuth 2.0 token endpoint URL | Yes (to enable OAuth) |
+| `FERN_AUTH_CLIENT_ID` | The OAuth client ID | Yes (if OAuth enabled) |
+| `FERN_AUTH_CLIENT_SECRET` | The OAuth client secret/password | Yes (if OAuth enabled) |
+| `FERN_CLIENT_SCOPE` | Space-separated list of OAuth scopes to request | No (optional) |
+
+#### Behavior
+
+- **OAuth Disabled**: If `AUTH_URL` is not set, the client will operate without authentication (backward compatible behavior).
+- **OAuth Enabled**: If `AUTH_URL` is set, the client will:
+  1. Validate that `FERN_AUTH_CLIENT_ID` and `FERN_AUTH_CLIENT_SECRET` are also provided
+  2. Request an access token from the OAuth server using client credentials grant
+  3. Include requested scopes in the token request if `FERN_CLIENT_SCOPE` is set
+  4. Include the Bearer token in the Authorization header for all API calls to the Fern backend
+  5. Automatically refresh the token when it expires
+
+#### Examples with OAuth
+
+##### Without OAuth (default)
+```sh
+fern-junit-client send -u "http://localhost:8080" -p "77b34e74-5631-5a71-b8ce-97b9d6bab10a" -f "report.xml"
+```
+
+##### With OAuth
+```sh
+export AUTH_URL="https://oauth.example.com/token"
+export FERN_AUTH_CLIENT_ID="your-client-id"
+export FERN_AUTH_CLIENT_SECRET="your-client-secret"
+
+fern-junit-client send -u "http://localhost:8080" -p "77b34e74-5631-5a71-b8ce-97b9d6bab10a" -f "report.xml"
+```
+
+##### With OAuth and Scopes
+```sh
+export AUTH_URL="https://oauth.example.com/token"
+export FERN_AUTH_CLIENT_ID="your-client-id"
+export FERN_AUTH_CLIENT_SECRET="your-client-secret"
+export FERN_CLIENT_SCOPE="read write admin"
+
+fern-junit-client send -u "http://localhost:8080" -p "77b34e74-5631-5a71-b8ce-97b9d6bab10a" -f "report.xml"
+```
+
+##### Verbose Mode
+Use the `--verbose` flag to see OAuth authentication status:
+```sh
+fern-junit-client send -u "http://localhost:8080" -p "77b34e74-5631-5a71-b8ce-97b9d6bab10a" -f "report.xml" --verbose
+```
+
 ## See Also
 
 * [Fern UI](https://github.com/guidewire-oss/fern-ui)
-* [Fern Reporter](https://github.com/guidewire-oss/fern-reporter)
+* [Fern Platform](https://github.com/guidewire-oss/fern-platform)
 * [Fern Ginkgo Client](https://github.com/guidewire-oss/fern-ginkgo-client)
 
 ## Development

--- a/cmd/send.go
+++ b/cmd/send.go
@@ -29,8 +29,8 @@ var sendCmd = &cobra.Command{
 }
 
 func init() {
-	sendCmd.PersistentFlags().StringVarP(&fernUrl, "fern-url", "u", "", "base URL of the Fern Reporter instance to send test reports to (required)")
-	sendCmd.PersistentFlags().StringVarP(&projectId, "project-id", "p", "", "Id of the project to associate test reports with (required). You must register the application first in fern-reporter")
+	sendCmd.PersistentFlags().StringVarP(&fernUrl, "fern-url", "u", "", "base URL of the Fern Platform instance to send test reports to (required)")
+	sendCmd.PersistentFlags().StringVarP(&projectId, "project-id", "p", "", "Id of the project to associate test reports with (required). You must register the application first in Fern Platform")
 	sendCmd.PersistentFlags().StringVarP(&filePattern, "file-pattern", "f", "", "file name pattern of test reports to send to Fern (required)")
 	sendCmd.PersistentFlags().StringVarP(&tags, "tags", "t", "", "comma-separated tags to be included on runs")
 	if err := sendCmd.MarkPersistentFlagRequired("fern-url"); err != nil {

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -34,7 +34,9 @@ type OAuthClient struct {
 }
 
 // NewOAuthClient creates a new OAuth client
-func NewOAuthClient() *OAuthClient {
+// Returns nil if OAuth is not configured (no AUTH_URL set)
+// Returns an error if OAuth is partially configured (missing required parameters)
+func NewOAuthClient() (*OAuthClient, error) {
 	config := &OAuthConfig{
 		TokenURL:       os.Getenv("AUTH_URL"),
 		ClientID:       os.Getenv("FERN_AUTH_CLIENT_ID"),
@@ -42,19 +44,27 @@ func NewOAuthClient() *OAuthClient {
 		Scopes:         os.Getenv("FERN_CLIENT_SCOPE"),
 	}
 
-	// If token URL is not set, OAuth is disabled
+	// If token URL is not set, OAuth is disabled - this is OK
 	if config.TokenURL == "" {
-		return nil
+		return nil, nil
 	}
 
-	// Validate required OAuth parameters
-	if config.ClientID == "" || config.ClientPassword == "" {
-		return nil
+	// If AUTH_URL is set, validate that we have all required OAuth parameters
+	var missingParams []string
+	if config.ClientID == "" {
+		missingParams = append(missingParams, "FERN_AUTH_CLIENT_ID")
+	}
+	if config.ClientPassword == "" {
+		missingParams = append(missingParams, "FERN_AUTH_CLIENT_SECRET")
+	}
+
+	if len(missingParams) > 0 {
+		return nil, fmt.Errorf("OAuth configuration error: AUTH_URL is set but missing required parameters: %s", strings.Join(missingParams, ", "))
 	}
 
 	return &OAuthClient{
 		config: config,
-	}
+	}, nil
 }
 
 // GetToken fetches a new OAuth token or returns the cached one if still valid

--- a/pkg/auth/oauth.go
+++ b/pkg/auth/oauth.go
@@ -1,0 +1,181 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// OAuthConfig holds OAuth configuration
+type OAuthConfig struct {
+	TokenURL       string
+	ClientID       string
+	ClientPassword string
+	Scopes         string
+}
+
+// TokenResponse represents the OAuth token response
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope,omitempty"`
+}
+
+// OAuthClient handles OAuth authentication
+type OAuthClient struct {
+	config      *OAuthConfig
+	token       *TokenResponse
+	tokenExpiry time.Time
+}
+
+// NewOAuthClient creates a new OAuth client
+func NewOAuthClient() *OAuthClient {
+	config := &OAuthConfig{
+		TokenURL:       os.Getenv("AUTH_URL"),
+		ClientID:       os.Getenv("FERN_AUTH_CLIENT_ID"),
+		ClientPassword: os.Getenv("FERN_AUTH_CLIENT_SECRET"),
+		Scopes:         os.Getenv("FERN_CLIENT_SCOPE"),
+	}
+
+	// If token URL is not set, OAuth is disabled
+	if config.TokenURL == "" {
+		return nil
+	}
+
+	// Validate required OAuth parameters
+	if config.ClientID == "" || config.ClientPassword == "" {
+		return nil
+	}
+
+	return &OAuthClient{
+		config: config,
+	}
+}
+
+// GetToken fetches a new OAuth token or returns the cached one if still valid
+func (c *OAuthClient) GetToken() (string, error) {
+	if c == nil {
+		return "", nil
+	}
+
+	// Check if we have a valid cached token
+	if c.token != nil && time.Now().Before(c.tokenExpiry) {
+		return c.token.AccessToken, nil
+	}
+
+	// Fetch new token
+	if err := c.fetchToken(); err != nil {
+		return "", fmt.Errorf("failed to fetch OAuth token: %w", err)
+	}
+
+	return c.token.AccessToken, nil
+}
+
+// fetchToken fetches a new OAuth token from the authorization server
+func (c *OAuthClient) fetchToken() error {
+	// Prepare the token request
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", c.config.ClientID)
+	data.Set("client_secret", c.config.ClientPassword)
+
+	// Add scopes if provided
+	if c.config.Scopes != "" {
+		data.Set("scope", c.config.Scopes)
+	}
+
+	req, err := http.NewRequest("POST", c.config.TokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create token request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// Send the request
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token request failed with status: %d", resp.StatusCode)
+	}
+
+	// Parse the response
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	// Store the token and calculate expiry
+	c.token = &tokenResp
+	// Subtract 30 seconds from expiry to ensure we refresh before it actually expires
+	expiryDuration := time.Duration(tokenResp.ExpiresIn-30) * time.Second
+	c.tokenExpiry = time.Now().Add(expiryDuration)
+
+	return nil
+}
+
+// AddAuthHeader adds the OAuth bearer token to the request header if OAuth is enabled
+func (c *OAuthClient) AddAuthHeader(req *http.Request) error {
+	if c == nil {
+		// OAuth is not enabled
+		return nil
+	}
+
+	token, err := c.GetToken()
+	if err != nil {
+		return err
+	}
+
+	if token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	return nil
+}
+
+// IsEnabled returns whether OAuth is enabled
+func (c *OAuthClient) IsEnabled() bool {
+	return c != nil
+}
+
+// HTTPClient returns an http.Client with OAuth authentication if enabled
+func (c *OAuthClient) HTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &OAuthTransport{
+			Base:        http.DefaultTransport,
+			OAuthClient: c,
+		},
+	}
+}
+
+// OAuthTransport is an http.RoundTripper that adds OAuth authentication
+type OAuthTransport struct {
+	Base        http.RoundTripper
+	OAuthClient *OAuthClient
+}
+
+// RoundTrip implements the http.RoundTripper interface
+func (t *OAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request to avoid modifying the original
+	reqCopy := req.Clone(req.Context())
+
+	// Add OAuth header
+	if err := t.OAuthClient.AddAuthHeader(reqCopy); err != nil {
+		return nil, err
+	}
+
+	// Use the base transport to send the request
+	return t.Base.RoundTrip(reqCopy)
+}

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -84,6 +84,8 @@ func TestNewOAuthClient(t *testing.T) {
 			clientPassword string
 			scopes         string
 			expectNil      bool
+			expectError    bool
+			errorContains  string
 		}{
 			{
 				name:           "all OAuth vars set with scopes",
@@ -92,6 +94,7 @@ func TestNewOAuthClient(t *testing.T) {
 				clientPassword: testClientSecret,
 				scopes:         testScopes,
 				expectNil:      false,
+				expectError:    false,
 			},
 			{
 				name:           "OAuth vars set without scopes",
@@ -100,6 +103,7 @@ func TestNewOAuthClient(t *testing.T) {
 				clientPassword: testClientSecret,
 				scopes:         "",
 				expectNil:      false,
+				expectError:    false,
 			},
 			{
 				name:           "missing token URL (OAuth disabled)",
@@ -107,6 +111,7 @@ func TestNewOAuthClient(t *testing.T) {
 				clientID:       testClientID,
 				clientPassword: testClientSecret,
 				expectNil:      true,
+				expectError:    false,
 			},
 			{
 				name:           "missing client ID",
@@ -114,6 +119,8 @@ func TestNewOAuthClient(t *testing.T) {
 				clientID:       "",
 				clientPassword: testClientSecret,
 				expectNil:      true,
+				expectError:    true,
+				errorContains:  "FERN_AUTH_CLIENT_ID",
 			},
 			{
 				name:           "missing client password",
@@ -121,19 +128,32 @@ func TestNewOAuthClient(t *testing.T) {
 				clientID:       testClientID,
 				clientPassword: "",
 				expectNil:      true,
+				expectError:    true,
+				errorContains:  "FERN_AUTH_CLIENT_SECRET",
 			},
 			{
 				name:      "all vars empty",
 				tokenURL:  "",
 				clientID:  "",
 				expectNil: true,
+				expectError: false,
 			},
 		}
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				setOAuthEnv(tt.tokenURL, tt.clientID, tt.clientPassword, tt.scopes)
-				client := NewOAuthClient()
+				client, err := NewOAuthClient()
+
+				if tt.expectError {
+					if err == nil {
+						t.Errorf("Expected error but got nil")
+					} else if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+						t.Errorf("Error = %v, should contain %v", err, tt.errorContains)
+					}
+				} else if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
 
 				if tt.expectNil && client != nil {
 					t.Errorf("Expected nil but got client")

--- a/pkg/auth/oauth_test.go
+++ b/pkg/auth/oauth_test.go
@@ -1,0 +1,585 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test constants
+const (
+	testClientID       = "test-client"
+	testClientSecret   = "test-secret"
+	testTokenURL       = "https://auth.example.com/token"
+	testAccessToken    = "test-access-token"
+	testBearerToken    = "test-bearer-token"
+	testScopes         = "read write admin"
+)
+
+// Helper function to save and restore environment variables
+func withCleanEnv(t *testing.T, fn func()) {
+	t.Helper()
+	origTokenURL := os.Getenv("AUTH_URL")
+	origClientID := os.Getenv("FERN_AUTH_CLIENT_ID")
+	origClientPassword := os.Getenv("FERN_AUTH_CLIENT_SECRET")
+	origScopes := os.Getenv("FERN_CLIENT_SCOPE")
+
+	defer func() {
+		os.Setenv("AUTH_URL", origTokenURL)
+		os.Setenv("FERN_AUTH_CLIENT_ID", origClientID)
+		os.Setenv("FERN_AUTH_CLIENT_SECRET", origClientPassword)
+		os.Setenv("FERN_CLIENT_SCOPE", origScopes)
+	}()
+
+	fn()
+}
+
+// Helper function to set OAuth environment variables
+func setOAuthEnv(tokenURL, clientID, clientPassword, scopes string) {
+	os.Setenv("AUTH_URL", tokenURL)
+	os.Setenv("FERN_AUTH_CLIENT_ID", clientID)
+	os.Setenv("FERN_AUTH_CLIENT_SECRET", clientPassword)
+	os.Setenv("FERN_CLIENT_SCOPE", scopes)
+}
+
+
+// Helper function to create a mock OAuth server with standard response
+func createMockOAuthServer(t *testing.T, token string, expiresIn int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		response := TokenResponse{
+			AccessToken: token,
+			TokenType:   "Bearer",
+			ExpiresIn:   expiresIn,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+}
+
+// Helper function to verify error expectations
+func assertError(t *testing.T, err error, expectError bool, errorContains string) {
+	t.Helper()
+	if expectError && err == nil {
+		t.Errorf("Expected error but got nil")
+	} else if !expectError && err != nil {
+		t.Errorf("Unexpected error = %v", err)
+	} else if expectError && err != nil && errorContains != "" {
+		if !strings.Contains(err.Error(), errorContains) {
+			t.Errorf("Error = %v, expected to contain %s", err, errorContains)
+		}
+	}
+}
+
+func TestNewOAuthClient(t *testing.T) {
+	withCleanEnv(t, func() {
+		tests := []struct {
+			name           string
+			tokenURL       string
+			clientID       string
+			clientPassword string
+			scopes         string
+			expectNil      bool
+		}{
+			{
+				name:           "all OAuth vars set with scopes",
+				tokenURL:       testTokenURL,
+				clientID:       testClientID,
+				clientPassword: testClientSecret,
+				scopes:         testScopes,
+				expectNil:      false,
+			},
+			{
+				name:           "OAuth vars set without scopes",
+				tokenURL:       testTokenURL,
+				clientID:       testClientID,
+				clientPassword: testClientSecret,
+				scopes:         "",
+				expectNil:      false,
+			},
+			{
+				name:           "missing token URL (OAuth disabled)",
+				tokenURL:       "",
+				clientID:       testClientID,
+				clientPassword: testClientSecret,
+				expectNil:      true,
+			},
+			{
+				name:           "missing client ID",
+				tokenURL:       testTokenURL,
+				clientID:       "",
+				clientPassword: testClientSecret,
+				expectNil:      true,
+			},
+			{
+				name:           "missing client password",
+				tokenURL:       testTokenURL,
+				clientID:       testClientID,
+				clientPassword: "",
+				expectNil:      true,
+			},
+			{
+				name:      "all vars empty",
+				tokenURL:  "",
+				clientID:  "",
+				expectNil: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				setOAuthEnv(tt.tokenURL, tt.clientID, tt.clientPassword, tt.scopes)
+				client := NewOAuthClient()
+
+				if tt.expectNil && client != nil {
+					t.Errorf("Expected nil but got client")
+				} else if !tt.expectNil && client == nil {
+					t.Errorf("Expected client but got nil")
+				}
+
+				// Verify scopes are set correctly when client is created
+				if !tt.expectNil && client != nil && client.config.Scopes != tt.scopes {
+					t.Errorf("Scopes = %v, want %v", client.config.Scopes, tt.scopes)
+				}
+			})
+		}
+	})
+}
+
+func TestOAuthClient_GetToken(t *testing.T) {
+	t.Run("basic token operations", func(t *testing.T) {
+		tokenCallCount := 0
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tokenCallCount++
+
+			// Verify request
+			if r.Method != "POST" {
+				t.Errorf("Expected POST request, got %s", r.Method)
+			}
+			if r.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+				t.Errorf("Expected Content-Type: application/x-www-form-urlencoded, got %s", r.Header.Get("Content-Type"))
+			}
+
+			// Parse and verify form
+			r.ParseForm()
+			if r.FormValue("grant_type") != "client_credentials" {
+				t.Errorf("Expected grant_type=client_credentials, got %s", r.FormValue("grant_type"))
+			}
+			if r.FormValue("client_id") != testClientID {
+				t.Errorf("Expected client_id=%s, got %s", testClientID, r.FormValue("client_id"))
+			}
+			if r.FormValue("client_secret") != testClientSecret {
+				t.Errorf("Expected client_secret=%s, got %s", testClientSecret, r.FormValue("client_secret"))
+			}
+
+			// Return different tokens for each call
+			response := TokenResponse{
+				AccessToken: testAccessToken + "-" + string(rune(tokenCallCount+'0')),
+				TokenType:   "Bearer",
+				ExpiresIn:   3600,
+				Scope:       "test-scope",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer mockServer.Close()
+
+		client := &OAuthClient{
+			config: &OAuthConfig{
+				TokenURL:       mockServer.URL,
+				ClientID:       testClientID,
+				ClientPassword: testClientSecret,
+			},
+		}
+
+		// Test initial token fetch
+		token, err := client.GetToken()
+		if err != nil {
+			t.Fatalf("GetToken() error = %v", err)
+		}
+		if token != testAccessToken+"-1" {
+			t.Errorf("Expected token %s-1, got %s", testAccessToken, token)
+		}
+		if tokenCallCount != 1 {
+			t.Errorf("Expected 1 token call, got %d", tokenCallCount)
+		}
+
+		// Test cached token (should not make another call)
+		token2, err := client.GetToken()
+		if err != nil {
+			t.Fatalf("GetToken() cached error = %v", err)
+		}
+		if token2 != testAccessToken+"-1" {
+			t.Errorf("Expected cached token %s-1, got %s", testAccessToken, token2)
+		}
+		if tokenCallCount != 1 {
+			t.Errorf("Expected still 1 token call for cached token, got %d", tokenCallCount)
+		}
+
+		// Test token expiry and refresh
+		client.tokenExpiry = time.Now().Add(-1 * time.Hour)
+		token3, err := client.GetToken()
+		if err != nil {
+			t.Fatalf("GetToken() refresh error = %v", err)
+		}
+		if token3 != testAccessToken+"-2" {
+			t.Errorf("Expected new token %s-2, got %s", testAccessToken, token3)
+		}
+		if tokenCallCount != 2 {
+			t.Errorf("Expected 2 token calls after expiry, got %d", tokenCallCount)
+		}
+	})
+
+	t.Run("with scopes", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.ParseForm()
+			receivedScopes := r.FormValue("scope")
+
+			if receivedScopes != testScopes {
+				t.Errorf("Expected scope=%s, got %s", testScopes, receivedScopes)
+			}
+
+			response := TokenResponse{
+				AccessToken: "token-with-scopes",
+				TokenType:   "Bearer",
+				ExpiresIn:   3600,
+				Scope:       receivedScopes,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer mockServer.Close()
+
+		client := &OAuthClient{
+			config: &OAuthConfig{
+				TokenURL:       mockServer.URL,
+				ClientID:       testClientID,
+				ClientPassword: testClientSecret,
+				Scopes:         testScopes,
+			},
+		}
+
+		token, err := client.GetToken()
+		if err != nil {
+			t.Fatalf("GetToken() with scopes error = %v", err)
+		}
+		if token != "token-with-scopes" {
+			t.Errorf("Expected token-with-scopes, got %s", token)
+		}
+	})
+
+	t.Run("without scopes", func(t *testing.T) {
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.ParseForm()
+
+			if r.FormValue("scope") != "" {
+				t.Errorf("Expected no scope parameter, but got: %s", r.FormValue("scope"))
+			}
+
+			response := TokenResponse{
+				AccessToken: "token-no-scopes",
+				TokenType:   "Bearer",
+				ExpiresIn:   3600,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer mockServer.Close()
+
+		client := &OAuthClient{
+			config: &OAuthConfig{
+				TokenURL:       mockServer.URL,
+				ClientID:       testClientID,
+				ClientPassword: testClientSecret,
+				Scopes:         "",
+			},
+		}
+
+		token, err := client.GetToken()
+		if err != nil {
+			t.Fatalf("GetToken() without scopes error = %v", err)
+		}
+		if token != "token-no-scopes" {
+			t.Errorf("Expected token-no-scopes, got %s", token)
+		}
+	})
+
+	t.Run("nil client", func(t *testing.T) {
+		var client *OAuthClient
+		token, err := client.GetToken()
+		if err != nil {
+			t.Errorf("GetToken() on nil client should not return error, got %v", err)
+		}
+		if token != "" {
+			t.Errorf("GetToken() on nil client should return empty string, got %s", token)
+		}
+	})
+
+	t.Run("error cases", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			serverResponse func(w http.ResponseWriter, r *http.Request)
+			expectError    bool
+			errorContains  string
+		}{
+			{
+				name: "server returns 401",
+				serverResponse: func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusUnauthorized)
+				},
+				expectError:   true,
+				errorContains: "token request failed with status: 401",
+			},
+			{
+				name: "server returns 500",
+				serverResponse: func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				},
+				expectError:   true,
+				errorContains: "token request failed with status: 500",
+			},
+			{
+				name: "server returns invalid JSON",
+				serverResponse: func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("not valid json"))
+				},
+				expectError:   true,
+				errorContains: "failed to decode token response",
+			},
+			{
+				name: "server timeout",
+				serverResponse: func(w http.ResponseWriter, r *http.Request) {
+					time.Sleep(35 * time.Second)
+				},
+				expectError:   true,
+				errorContains: "failed to send token request",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if tt.name == "server timeout" && testing.Short() {
+					t.Skip("Skipping timeout test in short mode")
+				}
+
+				mockServer := httptest.NewServer(http.HandlerFunc(tt.serverResponse))
+				defer mockServer.Close()
+
+				client := &OAuthClient{
+					config: &OAuthConfig{
+						TokenURL:       mockServer.URL,
+						ClientID:       testClientID,
+						ClientPassword: testClientSecret,
+					},
+				}
+
+				_, err := client.GetToken()
+				assertError(t, err, tt.expectError, tt.errorContains)
+			})
+		}
+	})
+}
+
+func TestOAuthClient_AddAuthHeader(t *testing.T) {
+	t.Run("adds auth header", func(t *testing.T) {
+		mockServer := createMockOAuthServer(t, testBearerToken, 3600)
+		defer mockServer.Close()
+
+		client := &OAuthClient{
+			config: &OAuthConfig{
+				TokenURL:       mockServer.URL,
+				ClientID:       testClientID,
+				ClientPassword: testClientSecret,
+			},
+		}
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+
+		err = client.AddAuthHeader(req)
+		if err != nil {
+			t.Fatalf("AddAuthHeader() error = %v", err)
+		}
+
+		authHeader := req.Header.Get("Authorization")
+		expected := "Bearer " + testBearerToken
+		if authHeader != expected {
+			t.Errorf("Expected Authorization header %s, got %s", expected, authHeader)
+		}
+	})
+
+	t.Run("nil client", func(t *testing.T) {
+		var client *OAuthClient
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+
+		err = client.AddAuthHeader(req)
+		if err != nil {
+			t.Errorf("AddAuthHeader() on nil client should not return error, got %v", err)
+		}
+
+		if req.Header.Get("Authorization") != "" {
+			t.Errorf("AddAuthHeader() on nil client should not add header, got %s", req.Header.Get("Authorization"))
+		}
+	})
+}
+
+func TestOAuthClient_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		client   *OAuthClient
+		expected bool
+	}{
+		{
+			name:     "nil client",
+			client:   nil,
+			expected: false,
+		},
+		{
+			name: "initialized client",
+			client: &OAuthClient{
+				config: &OAuthConfig{
+					TokenURL:       testTokenURL,
+					ClientID:       testClientID,
+					ClientPassword: testClientSecret,
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := tt.client.IsEnabled(); result != tt.expected {
+				t.Errorf("IsEnabled() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOAuthClient_HTTPClient(t *testing.T) {
+	mockServer := createMockOAuthServer(t, "http-client-token", 3600)
+	defer mockServer.Close()
+
+	client := &OAuthClient{
+		config: &OAuthConfig{
+			TokenURL:       mockServer.URL,
+			ClientID:       testClientID,
+			ClientPassword: testClientSecret,
+		},
+	}
+
+	httpClient := client.HTTPClient()
+	if httpClient == nil {
+		t.Fatal("HTTPClient() returned nil")
+	}
+
+	if httpClient.Timeout != 30*time.Second {
+		t.Errorf("Expected timeout of 30s, got %v", httpClient.Timeout)
+	}
+
+	transport, ok := httpClient.Transport.(*OAuthTransport)
+	if !ok {
+		t.Fatal("HTTPClient() transport is not OAuthTransport")
+	}
+	if transport.OAuthClient != client {
+		t.Error("OAuthTransport does not reference the correct OAuth client")
+	}
+}
+
+func TestOAuthTransport_RoundTrip(t *testing.T) {
+	t.Run("adds auth header to request", func(t *testing.T) {
+		oauthCallCount := 0
+		mockOAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			oauthCallCount++
+			response := TokenResponse{
+				AccessToken: "transport-token",
+				TokenType:   "Bearer",
+				ExpiresIn:   3600,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(response)
+		}))
+		defer mockOAuthServer.Close()
+
+		authHeaderReceived := ""
+		mockAPIServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeaderReceived = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("success"))
+		}))
+		defer mockAPIServer.Close()
+
+		oauthClient := &OAuthClient{
+			config: &OAuthConfig{
+				TokenURL:       mockOAuthServer.URL,
+				ClientID:       testClientID,
+				ClientPassword: testClientSecret,
+			},
+		}
+
+		transport := &OAuthTransport{
+			Base:        http.DefaultTransport,
+			OAuthClient: oauthClient,
+		}
+
+		req, err := http.NewRequest("GET", mockAPIServer.URL, nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+
+		resp, err := transport.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("RoundTrip() error = %v", err)
+		}
+		defer resp.Body.Close()
+
+		if oauthCallCount != 1 {
+			t.Errorf("Expected 1 OAuth call, got %d", oauthCallCount)
+		}
+
+		expected := "Bearer transport-token"
+		if authHeaderReceived != expected {
+			t.Errorf("Expected Authorization header %s, got %s", expected, authHeaderReceived)
+		}
+
+		// Verify original request was not modified
+		if req.Header.Get("Authorization") != "" {
+			t.Error("Original request should not be modified")
+		}
+	})
+
+	t.Run("handles OAuth failure", func(t *testing.T) {
+		oauthClient := &OAuthClient{
+			config: &OAuthConfig{
+				TokenURL:       "http://invalid-url-that-does-not-exist",
+				ClientID:       testClientID,
+				ClientPassword: testClientSecret,
+			},
+		}
+
+		transport := &OAuthTransport{
+			Base:        http.DefaultTransport,
+			OAuthClient: oauthClient,
+		}
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+
+		_, err = transport.RoundTrip(req)
+		if err == nil {
+			t.Error("RoundTrip() expected error when OAuth fails")
+		}
+	})
+}

--- a/pkg/client/send.go
+++ b/pkg/client/send.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
+	"os"
 
+	"github.com/guidewire-oss/fern-junit-client/pkg/auth"
 	"github.com/guidewire-oss/fern-junit-client/pkg/models/fern"
 )
 
@@ -17,20 +20,110 @@ func sendTestRun(testRun fern.TestRun, fernUrl string, verbose bool) error {
 		return fmt.Errorf("failed to serialize TestRun: %w", err)
 	}
 
-	endpoint, err := url.JoinPath(fernUrl, "api", "testrun")
+	// Log the request payload in verbose mode
+	if verbose {
+		// Pretty print the JSON for better readability
+		var prettyJSON bytes.Buffer
+		if err := json.Indent(&prettyJSON, payload, "", "  "); err == nil {
+			log.Default().Printf("Request Payload:\n%s\n", prettyJSON.String())
+		} else {
+			// If pretty print fails, just print raw
+			log.Default().Printf("Request Payload: %s\n", string(payload))
+		}
+	}
+
+	// Check for custom API endpoint path from environment variable
+	// Default to "api/v1/test-runs" if not set
+	apiPath := os.Getenv("FERN_API_ENDPOINT_PATH")
+	if apiPath == "" {
+		apiPath = "api/v1/test-runs"
+	}
+
+	endpoint, err := url.JoinPath(fernUrl, apiPath)
 	if err != nil {
 		return fmt.Errorf("failed to construct endpoint URL: %w", err)
+	}
+
+	if verbose {
+		log.Default().Printf("Using API endpoint path: %s\n", apiPath)
+		log.Default().Printf("Full endpoint URL: %s\n", endpoint)
+	}
+
+	// Create OAuth client
+	oauthClient := auth.NewOAuthClient()
+
+	// Create HTTP request
+	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Add OAuth authentication if enabled
+	if oauthClient != nil && oauthClient.IsEnabled() {
+		if verbose {
+			log.Default().Println("OAuth authentication is enabled, fetching token...")
+		}
+		if err := oauthClient.AddAuthHeader(req); err != nil {
+			return fmt.Errorf("failed to add OAuth authentication: %w", err)
+		}
+	} else if verbose {
+		log.Default().Println("OAuth authentication is not configured, proceeding without authentication")
 	}
 
 	if verbose {
 		log.Default().Printf("Sending POST request to %s...\n", endpoint)
 	}
 
-	resp, err := http.Post(endpoint, "application/json", bytes.NewReader(payload))
+	// Use the OAuth client's HTTP client if OAuth is enabled, otherwise use default
+	var httpClient *http.Client
+	if oauthClient != nil && oauthClient.IsEnabled() {
+		httpClient = oauthClient.HTTPClient()
+	} else {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
+
+	// Log response details when verbose is enabled
+	if verbose {
+		log.Default().Printf("Response Status: %s\n", resp.Status)
+		log.Default().Printf("Response Status Code: %d\n", resp.StatusCode)
+
+		// Read the entire response body
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Default().Printf("Error reading response body: %v\n", err)
+		} else {
+			// Replace the response body so it can still be read later if needed
+			resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+			if len(bodyBytes) > 0 {
+				// Try to pretty print JSON if possible
+				var prettyJSON bytes.Buffer
+				if err := json.Indent(&prettyJSON, bodyBytes, "", "  "); err == nil {
+					log.Default().Printf("Response Body:\n%s\n", prettyJSON.String())
+				} else {
+					// If not JSON, print as is
+					log.Default().Printf("Response Body:\n%s\n", string(bodyBytes))
+				}
+			} else {
+				log.Default().Println("Response Body: (empty)")
+			}
+		}
+
+		// Log response headers
+		log.Default().Println("Response Headers:")
+		for key, values := range resp.Header {
+			for _, value := range values {
+				log.Default().Printf("  %s: %s\n", key, value)
+			}
+		}
+	}
 
 	if resp.StatusCode >= 300 {
 		return fmt.Errorf("unexpected response code: %d", resp.StatusCode)

--- a/pkg/client/send.go
+++ b/pkg/client/send.go
@@ -50,7 +50,11 @@ func sendTestRun(testRun fern.TestRun, fernUrl string, verbose bool) error {
 	}
 
 	// Create OAuth client
-	oauthClient := auth.NewOAuthClient()
+	oauthClient, err := auth.NewOAuthClient()
+	if err != nil {
+		// OAuth configuration error - fail fast
+		return fmt.Errorf("OAuth configuration error: %w", err)
+	}
 
 	// Create HTTP request
 	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(payload))

--- a/pkg/client/send_auth_test.go
+++ b/pkg/client/send_auth_test.go
@@ -1,0 +1,384 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/guidewire-oss/fern-junit-client/pkg/auth"
+	"github.com/guidewire-oss/fern-junit-client/pkg/models/fern"
+)
+
+// Test constants
+const (
+	testClientID        = "test-client-id"
+	testClientSecret    = "test-client-secret"
+	testProjectID       = "test-project-123"
+	testAccessToken     = "test-access-token-123"
+	testScopes          = "read write admin"
+	integrationClientID = "integration-client"
+	integrationSecret   = "integration-secret"
+	testAPIPath         = "api/v1/test-runs"
+	customAPIPath       = "custom/api/path"
+)
+
+// Helper function to save and restore OAuth environment variables
+func withCleanOAuthEnv(t *testing.T, fn func()) {
+	t.Helper()
+	origTokenURL := os.Getenv("AUTH_URL")
+	origClientID := os.Getenv("FERN_AUTH_CLIENT_ID")
+	origClientPassword := os.Getenv("FERN_AUTH_CLIENT_SECRET")
+	origScopes := os.Getenv("FERN_CLIENT_SCOPE")
+	origAPIPath := os.Getenv("FERN_API_ENDPOINT_PATH")
+
+	defer func() {
+		os.Setenv("AUTH_URL", origTokenURL)
+		os.Setenv("FERN_AUTH_CLIENT_ID", origClientID)
+		os.Setenv("FERN_AUTH_CLIENT_SECRET", origClientPassword)
+		os.Setenv("FERN_CLIENT_SCOPE", origScopes)
+		os.Setenv("FERN_API_ENDPOINT_PATH", origAPIPath)
+	}()
+
+	fn()
+}
+
+// Helper function to set OAuth environment variables
+func setOAuthTestEnv(tokenURL, clientID, clientSecret, scopes string) {
+	os.Setenv("AUTH_URL", tokenURL)
+	os.Setenv("FERN_AUTH_CLIENT_ID", clientID)
+	os.Setenv("FERN_AUTH_CLIENT_SECRET", clientSecret)
+	if scopes != "" {
+		os.Setenv("FERN_CLIENT_SCOPE", scopes)
+	}
+}
+
+// Helper function to clear OAuth environment variables
+func clearOAuthTestEnv() {
+	os.Unsetenv("AUTH_URL")
+	os.Unsetenv("FERN_AUTH_CLIENT_ID")
+	os.Unsetenv("FERN_AUTH_CLIENT_SECRET")
+	os.Unsetenv("FERN_CLIENT_SCOPE")
+}
+
+// Helper function to create standard OAuth response
+func createTokenResponse(token string, scopes string) auth.TokenResponse {
+	return auth.TokenResponse{
+		AccessToken: token,
+		TokenType:   "Bearer",
+		ExpiresIn:   3600,
+		Scope:       scopes,
+	}
+}
+
+
+// Helper function to verify Fern server request
+func verifyFernRequest(t *testing.T, r *http.Request, expectedAuth string, expectedPath string) {
+	t.Helper()
+
+	// Verify authorization header
+	if expectedAuth != "" && r.Header.Get("Authorization") != expectedAuth {
+		t.Errorf("Expected Authorization: %s, got %s", expectedAuth, r.Header.Get("Authorization"))
+	} else if expectedAuth == "" && r.Header.Get("Authorization") != "" {
+		t.Errorf("Should not have Authorization header, got %s", r.Header.Get("Authorization"))
+	}
+
+	// Verify content type
+	if r.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("Expected Content-Type: application/json, got %s", r.Header.Get("Content-Type"))
+	}
+
+	// Verify method
+	if r.Method != "POST" {
+		t.Errorf("Expected POST request, got %s", r.Method)
+	}
+
+	// Verify path
+	if expectedPath != "" && !strings.Contains(r.URL.Path, expectedPath) {
+		t.Errorf("Expected path to contain %s, got %s", expectedPath, r.URL.Path)
+	}
+}
+
+
+func Test_sendTestRun_WithAuthentication(t *testing.T) {
+	withCleanOAuthEnv(t, func() {
+		tests := []struct {
+			name           string
+			setupEnv       func(oauthURL string)
+			oauthStatus    int
+			oauthToken     string
+			fernStatus     int
+			expectedAuth   string
+			expectedPath   string
+			expectError    bool
+			errorContains  string
+		}{
+			{
+				name: "successful authentication and send",
+				setupEnv: func(oauthURL string) {
+					setOAuthTestEnv(oauthURL, testClientID, testClientSecret, "")
+				},
+				oauthStatus:  http.StatusOK,
+				oauthToken:   testAccessToken,
+				fernStatus:   http.StatusOK,
+				expectedAuth: "Bearer " + testAccessToken,
+				expectedPath: testAPIPath,
+				expectError:  false,
+			},
+			{
+				name: "successful authentication with scopes",
+				setupEnv: func(oauthURL string) {
+					setOAuthTestEnv(oauthURL, testClientID, testClientSecret, testScopes)
+				},
+				oauthStatus:  http.StatusOK,
+				oauthToken:   "scoped-token",
+				fernStatus:   http.StatusOK,
+				expectedAuth: "Bearer scoped-token",
+				expectedPath: testAPIPath,
+				expectError:  false,
+			},
+			{
+				name: "authentication disabled - no oauth env vars",
+				setupEnv: func(oauthURL string) {
+					clearOAuthTestEnv()
+				},
+				fernStatus:   http.StatusOK,
+				expectedAuth: "",
+				expectedPath: testAPIPath,
+				expectError:  false,
+			},
+			{
+				name: "oauth token fetch fails",
+				setupEnv: func(oauthURL string) {
+					setOAuthTestEnv(oauthURL, testClientID, "wrong-password", "")
+				},
+				oauthStatus:   http.StatusUnauthorized,
+				expectError:   true,
+				errorContains: "failed to add OAuth authentication",
+			},
+			{
+				name: "custom API endpoint path",
+				setupEnv: func(oauthURL string) {
+					setOAuthTestEnv(oauthURL, testClientID, testClientSecret, "")
+					os.Setenv("FERN_API_ENDPOINT_PATH", customAPIPath)
+				},
+				oauthStatus:  http.StatusOK,
+				oauthToken:   "custom-endpoint-token",
+				fernStatus:   http.StatusOK,
+				expectedAuth: "Bearer custom-endpoint-token",
+				expectedPath: customAPIPath,
+				expectError:  false,
+			},
+			{
+				name: "fern server returns 401 with valid oauth",
+				setupEnv: func(oauthURL string) {
+					setOAuthTestEnv(oauthURL, testClientID, testClientSecret, "")
+				},
+				oauthStatus:   http.StatusOK,
+				oauthToken:    "valid-token",
+				fernStatus:    http.StatusUnauthorized,
+				expectedAuth:  "Bearer valid-token",
+				expectError:   true,
+				errorContains: "unexpected response code: 401",
+			},
+			{
+				name: "partial oauth config - missing client id",
+				setupEnv: func(oauthURL string) {
+					os.Setenv("AUTH_URL", oauthURL)
+					os.Unsetenv("FERN_AUTH_CLIENT_ID")
+					os.Setenv("FERN_AUTH_CLIENT_SECRET", testClientSecret)
+				},
+				fernStatus:   http.StatusOK,
+				expectedAuth: "",
+				expectedPath: testAPIPath,
+				expectError:  false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// Create OAuth server
+				var oauthCalled bool
+				mockOAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					oauthCalled = true
+
+					if tt.oauthStatus != http.StatusOK {
+						w.WriteHeader(tt.oauthStatus)
+						w.Write([]byte(`{"error": "invalid_client"}`))
+						return
+					}
+
+					// For scopes test, verify scopes are sent
+					if tt.name == "successful authentication with scopes" {
+						r.ParseForm()
+						if r.FormValue("scope") != testScopes {
+							t.Errorf("Expected scope='%s', got %s", testScopes, r.FormValue("scope"))
+						}
+					}
+
+					response := createTokenResponse(tt.oauthToken, "")
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+				}))
+				defer mockOAuthServer.Close()
+
+				// Create Fern server
+				var fernCalled bool
+				mockFernServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					fernCalled = true
+
+					// Read and verify body
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("Failed to read request body: %v", err)
+					}
+					defer r.Body.Close()
+
+					var testRun fern.TestRun
+					if err := json.Unmarshal(body, &testRun); err != nil {
+						t.Errorf("Failed to unmarshal test run: %v", err)
+					}
+
+					// Verify request
+					verifyFernRequest(t, r, tt.expectedAuth, tt.expectedPath)
+
+					// Send response
+					w.WriteHeader(tt.fernStatus)
+					if tt.fernStatus == http.StatusOK {
+						w.Write([]byte(`{"success": true}`))
+					} else {
+						w.Write([]byte(`{"error": "unauthorized"}`))
+					}
+				}))
+				defer mockFernServer.Close()
+
+				// Setup environment
+				tt.setupEnv(mockOAuthServer.URL)
+
+				// Create and send test run
+				testRun := fern.TestRun{
+					TestProjectID: testProjectID,
+					TestSeed:      12345,
+				}
+
+				err := sendTestRun(testRun, mockFernServer.URL, true)
+
+				// Check error expectations
+				if tt.expectError && err == nil {
+					t.Errorf("Expected error but got nil")
+				} else if !tt.expectError && err != nil {
+					t.Errorf("Unexpected error = %v", err)
+				} else if tt.expectError && err != nil && tt.errorContains != "" {
+					if !strings.Contains(err.Error(), tt.errorContains) {
+						t.Errorf("Error = %v, expected to contain %s", err, tt.errorContains)
+					}
+				}
+
+				// Verify OAuth server was called when expected
+				if tt.name == "authentication disabled - no oauth env vars" && oauthCalled {
+					t.Error("OAuth server should not be called when disabled")
+				}
+
+				// Verify Fern was called when expected
+				if !tt.expectError && !fernCalled && tt.name != "oauth token fetch fails" {
+					t.Error("Fern server was not called when expected")
+				}
+			})
+		}
+	})
+}
+
+func TestSendReports_Authentication(t *testing.T) {
+	withCleanOAuthEnv(t, func() {
+		t.Run("with authentication", func(t *testing.T) {
+			// Create OAuth server
+			oauthCallCount := 0
+			mockOAuthServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				oauthCallCount++
+				response := createTokenResponse(fmt.Sprintf("integration-token-%d", oauthCallCount), "")
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			}))
+			defer mockOAuthServer.Close()
+
+			// Create Fern server
+			var receivedAuthHeaders []string
+			mockFernServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authHeader := r.Header.Get("Authorization")
+				receivedAuthHeaders = append(receivedAuthHeaders, authHeader)
+
+				// Verify body
+				body, _ := io.ReadAll(r.Body)
+				defer r.Body.Close()
+
+				var testRun fern.TestRun
+				if err := json.Unmarshal(body, &testRun); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer mockFernServer.Close()
+
+			// Setup OAuth
+			setOAuthTestEnv(mockOAuthServer.URL, integrationClientID, integrationSecret, "")
+
+			// Run SendReports
+			err := SendReports(mockFernServer.URL, testProjectId, reportPassedPath, "auth-test", true)
+			if err != nil {
+				t.Fatalf("SendReports() with authentication failed: %v", err)
+			}
+
+			// Verify OAuth was called
+			if oauthCallCount < 1 {
+				t.Errorf("Expected at least 1 OAuth call, got %d", oauthCallCount)
+			}
+
+			// Verify auth header
+			if len(receivedAuthHeaders) < 1 {
+				t.Fatal("No auth headers received by Fern server")
+			}
+			expectedAuthHeader := "Bearer integration-token-1"
+			if receivedAuthHeaders[0] != expectedAuthHeader {
+				t.Errorf("Expected auth header %s, got %s", expectedAuthHeader, receivedAuthHeaders[0])
+			}
+		})
+
+		t.Run("without authentication", func(t *testing.T) {
+			// Clear OAuth env vars
+			clearOAuthTestEnv()
+
+			// Create Fern server that verifies no auth
+			mockFernServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify no auth header
+				if r.Header.Get("Authorization") != "" {
+					t.Errorf("Should not have Authorization header when OAuth disabled, got %s", r.Header.Get("Authorization"))
+				}
+
+				// Parse body
+				body, _ := io.ReadAll(r.Body)
+				defer r.Body.Close()
+
+				var testRun fern.TestRun
+				if err := json.Unmarshal(body, &testRun); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer mockFernServer.Close()
+
+			// Run SendReports
+			err := SendReports(mockFernServer.URL, testProjectId, reportPassedPath, "no-auth-test", false)
+			if err != nil {
+				t.Fatalf("SendReports() without authentication failed: %v", err)
+			}
+		})
+	})
+}

--- a/pkg/client/send_auth_test.go
+++ b/pkg/client/send_auth_test.go
@@ -75,7 +75,6 @@ func createTokenResponse(token string, scopes string) auth.TokenResponse {
 	}
 }
 
-
 // Helper function to verify Fern server request
 func verifyFernRequest(t *testing.T, r *http.Request, expectedAuth string, expectedPath string) {
 	t.Helper()
@@ -103,19 +102,18 @@ func verifyFernRequest(t *testing.T, r *http.Request, expectedAuth string, expec
 	}
 }
 
-
 func Test_sendTestRun_WithAuthentication(t *testing.T) {
 	withCleanOAuthEnv(t, func() {
 		tests := []struct {
-			name           string
-			setupEnv       func(oauthURL string)
-			oauthStatus    int
-			oauthToken     string
-			fernStatus     int
-			expectedAuth   string
-			expectedPath   string
-			expectError    bool
-			errorContains  string
+			name          string
+			setupEnv      func(oauthURL string)
+			oauthStatus   int
+			oauthToken    string
+			fernStatus    int
+			expectedAuth  string
+			expectedPath  string
+			expectError   bool
+			errorContains string
 		}{
 			{
 				name: "successful authentication and send",
@@ -191,11 +189,32 @@ func Test_sendTestRun_WithAuthentication(t *testing.T) {
 					os.Setenv("AUTH_URL", oauthURL)
 					os.Unsetenv("FERN_AUTH_CLIENT_ID")
 					os.Setenv("FERN_AUTH_CLIENT_SECRET", testClientSecret)
+					os.Unsetenv("FERN_API_ENDPOINT_PATH") // Clear custom endpoint
 				},
-				fernStatus:   http.StatusOK,
-				expectedAuth: "",
-				expectedPath: testAPIPath,
-				expectError:  false,
+				expectError:   true,
+				errorContains: "OAuth configuration error: AUTH_URL is set but missing required parameters: FERN_AUTH_CLIENT_ID",
+			},
+			{
+				name: "partial oauth config - missing client secret",
+				setupEnv: func(oauthURL string) {
+					os.Setenv("AUTH_URL", oauthURL)
+					os.Setenv("FERN_AUTH_CLIENT_ID", testClientID)
+					os.Unsetenv("FERN_AUTH_CLIENT_SECRET")
+					os.Unsetenv("FERN_API_ENDPOINT_PATH") // Clear custom endpoint
+				},
+				expectError:   true,
+				errorContains: "OAuth configuration error: AUTH_URL is set but missing required parameters: FERN_AUTH_CLIENT_SECRET",
+			},
+			{
+				name: "partial oauth config - missing both client id and secret",
+				setupEnv: func(oauthURL string) {
+					os.Setenv("AUTH_URL", oauthURL)
+					os.Unsetenv("FERN_AUTH_CLIENT_ID")
+					os.Unsetenv("FERN_AUTH_CLIENT_SECRET")
+					os.Unsetenv("FERN_API_ENDPOINT_PATH") // Clear custom endpoint
+				},
+				expectError:   true,
+				errorContains: "OAuth configuration error: AUTH_URL is set but missing required parameters: FERN_AUTH_CLIENT_ID, FERN_AUTH_CLIENT_SECRET",
 			},
 		}
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds optional OAuth 2.0 client-credentials auth and a configurable API endpoint path to the JUnit client to support secured Fern Platform deployments. Default behavior remains unchanged when OAuth is not configured.

- **New Features**
  - OAuth support via env vars: AUTH_URL, FERN_AUTH_CLIENT_ID, FERN_AUTH_CLIENT_SECRET, optional FERN_CLIENT_SCOPE; sends Bearer token and refreshes before expiry.
  - Configurable API endpoint path with FERN_API_ENDPOINT_PATH (default: api/v1/test-runs).
  - Verbose mode now logs payload, endpoint, OAuth status, response status/body/headers.
  - CLI help and README updated for Fern Platform and OAuth examples.
  - Added comprehensive unit tests for OAuth and authenticated send flow.

<sup>Written for commit 118575473e255429ed8a7527b7f4afcab24e025a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



