### PR TITLE
feat: add branch/commit/environment flags

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -14,6 +14,9 @@ var (
 	projectId   string
 	filePattern string
 	tags        string
+	branch      string
+	commitSha   string
+	environment string
 )
 
 var sendCmd = &cobra.Command{
@@ -21,7 +24,7 @@ var sendCmd = &cobra.Command{
 	Short: "Send JUnit test reports to Fern",
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := client.SendReports(fernUrl, projectId, filePattern, tags, verbose); err != nil {
+		if err := client.SendReports(fernUrl, projectId, filePattern, tags, branch, commitSha, environment, verbose); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 			os.Exit(1)
 		}
@@ -33,6 +36,9 @@ func init() {
 	sendCmd.PersistentFlags().StringVarP(&projectId, "project-id", "p", "", "Id of the project to associate test reports with (required). You must register the application first in Fern Platform")
 	sendCmd.PersistentFlags().StringVarP(&filePattern, "file-pattern", "f", "", "file name pattern of test reports to send to Fern (required)")
 	sendCmd.PersistentFlags().StringVarP(&tags, "tags", "t", "", "comma-separated tags to be included on runs")
+	sendCmd.PersistentFlags().StringVar(&branch, "branch", "", "git branch name for this run (falls back to $GITHUB_REF_NAME / $CI_COMMIT_REF_NAME)")
+	sendCmd.PersistentFlags().StringVar(&commitSha, "commit", "", "git commit SHA for this run (falls back to $GITHUB_SHA / $CI_COMMIT_SHA)")
+	sendCmd.PersistentFlags().StringVar(&environment, "environment", "", "environment label, e.g. ci, staging (falls back to $CI_ENVIRONMENT_NAME / $FERN_ENVIRONMENT)")
 	if err := sendCmd.MarkPersistentFlagRequired("fern-url"); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 		os.Exit(1)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,15 +2,36 @@ package client
 
 import (
 	"log"
+	"os"
 
 	"github.com/guidewire-oss/fern-junit-client/pkg/models/fern"
 	"github.com/guidewire-oss/fern-junit-client/pkg/util"
 )
 
-func SendReports(fernUrl, projectId, filePattern string, tags string, verbose bool) error {
+// SendReports parses JUnit XML reports and posts a TestRun to Fern Platform.
+// branch, commitSha, and environment may be empty strings; when empty the
+// function falls back to GITHUB_REF_NAME / GITHUB_SHA / CI_ENVIRONMENT_NAME
+// environment variables so that callers in CI pipelines get automatic population
+// without explicit flags.
+func SendReports(fernUrl, projectId, filePattern, tags, branch, commitSha, environment string, verbose bool) error {
 	var testRun fern.TestRun
 	testRun.TestProjectID = projectId
 	testRun.TestSeed = uint64(util.GlobalClock.Now().Nanosecond())
+
+	// Resolve git provenance: flag value wins; fall back to common CI env vars.
+	if branch == "" {
+		branch = firstNonEmpty(os.Getenv("GITHUB_REF_NAME"), os.Getenv("CI_COMMIT_REF_NAME"))
+	}
+	if commitSha == "" {
+		commitSha = firstNonEmpty(os.Getenv("GITHUB_SHA"), os.Getenv("CI_COMMIT_SHA"))
+	}
+	if environment == "" {
+		environment = firstNonEmpty(os.Getenv("CI_ENVIRONMENT_NAME"), os.Getenv("FERN_ENVIRONMENT"))
+	}
+
+	testRun.GitBranch = branch
+	testRun.GitSha = commitSha
+	testRun.Environment = environment
 
 	log.Default().Println("Parsing reports...")
 	if err := parseReports(&testRun, filePattern, tags, verbose); err != nil {
@@ -24,4 +45,14 @@ func SendReports(fernUrl, projectId, filePattern string, tags string, verbose bo
 	}
 	log.Default().Println("Sending reports succeeded!")
 	return nil
+}
+
+// firstNonEmpty returns the first non-empty string from the provided candidates.
+func firstNonEmpty(candidates ...string) string {
+	for _, s := range candidates {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -64,7 +64,7 @@ func TestSendReports(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := SendReports(tt.args.fernUrl, tt.args.projectId, tt.args.filePattern, tt.args.tags, tt.args.verbose); (err != nil) != tt.wantErr {
+			if err := SendReports(tt.args.fernUrl, tt.args.projectId, tt.args.filePattern, tt.args.tags, "", "", "", tt.args.verbose); (err != nil) != tt.wantErr {
 				t.Errorf("SendReports() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/client/provenance_test.go
+++ b/pkg/client/provenance_test.go
@@ -73,6 +73,29 @@ func TestSendReportsProvenance(t *testing.T) {
 		}
 	})
 
+	t.Run("falls back to secondary (GitLab/FERN) env vars", func(t *testing.T) {
+		// Null the primary GitHub vars so the secondary candidates win — robust
+		// even on a GitHub Actions runner where GITHUB_REF_NAME/SHA are set.
+		t.Setenv("GITHUB_REF_NAME", "")
+		t.Setenv("GITHUB_SHA", "")
+		t.Setenv("CI_ENVIRONMENT_NAME", "")
+		t.Setenv("CI_COMMIT_REF_NAME", "feature/gl")
+		t.Setenv("CI_COMMIT_SHA", "cafef00d")
+		t.Setenv("FERN_ENVIRONMENT", "review")
+
+		var got fern.TestRun
+		srv := captureServer(t, &got)
+		defer srv.Close()
+
+		if err := SendReports(srv.URL, testProjectId, reportPassedPath, exampleTags, "", "", "", false); err != nil {
+			t.Fatalf("SendReports() error = %v", err)
+		}
+		if got.GitBranch != "feature/gl" || got.GitSha != "cafef00d" || got.Environment != "review" {
+			t.Errorf("secondary fallback = {branch:%q sha:%q env:%q}, want {feature/gl cafef00d review}",
+				got.GitBranch, got.GitSha, got.Environment)
+		}
+	})
+
 	t.Run("explicit flag overrides env var", func(t *testing.T) {
 		t.Setenv("GITHUB_REF_NAME", "main")
 

--- a/pkg/client/provenance_test.go
+++ b/pkg/client/provenance_test.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/guidewire-oss/fern-junit-client/pkg/models/fern"
+)
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"first non-empty wins", []string{"a", "b"}, "a"},
+		{"skips leading empties", []string{"", "", "c"}, "c"},
+		{"all empty", []string{"", ""}, ""},
+		{"no candidates", nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := firstNonEmpty(tt.in...); got != tt.want {
+				t.Errorf("firstNonEmpty(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// captureServer records the TestRun payload of the last request it receives.
+func captureServer(t *testing.T, got *fern.TestRun) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, got)
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+func TestSendReportsProvenance(t *testing.T) {
+	t.Run("explicit flags populate the payload", func(t *testing.T) {
+		var got fern.TestRun
+		srv := captureServer(t, &got)
+		defer srv.Close()
+
+		if err := SendReports(srv.URL, testProjectId, reportPassedPath, exampleTags, "feature/x", "abc123", "staging", false); err != nil {
+			t.Fatalf("SendReports() error = %v", err)
+		}
+		if got.GitBranch != "feature/x" || got.GitSha != "abc123" || got.Environment != "staging" {
+			t.Errorf("payload provenance = {branch:%q sha:%q env:%q}, want {feature/x abc123 staging}",
+				got.GitBranch, got.GitSha, got.Environment)
+		}
+	})
+
+	t.Run("empty flags fall back to CI env vars", func(t *testing.T) {
+		t.Setenv("GITHUB_REF_NAME", "main")
+		t.Setenv("GITHUB_SHA", "deadbeef")
+		t.Setenv("CI_ENVIRONMENT_NAME", "prod")
+
+		var got fern.TestRun
+		srv := captureServer(t, &got)
+		defer srv.Close()
+
+		if err := SendReports(srv.URL, testProjectId, reportPassedPath, exampleTags, "", "", "", false); err != nil {
+			t.Fatalf("SendReports() error = %v", err)
+		}
+		if got.GitBranch != "main" || got.GitSha != "deadbeef" || got.Environment != "prod" {
+			t.Errorf("env fallback = {branch:%q sha:%q env:%q}, want {main deadbeef prod}",
+				got.GitBranch, got.GitSha, got.Environment)
+		}
+	})
+
+	t.Run("explicit flag overrides env var", func(t *testing.T) {
+		t.Setenv("GITHUB_REF_NAME", "main")
+
+		var got fern.TestRun
+		srv := captureServer(t, &got)
+		defer srv.Close()
+
+		if err := SendReports(srv.URL, testProjectId, reportPassedPath, exampleTags, "release/1.0", "", "", false); err != nil {
+			t.Fatalf("SendReports() error = %v", err)
+		}
+		if got.GitBranch != "release/1.0" {
+			t.Errorf("branch = %q, want release/1.0 (explicit flag must override env)", got.GitBranch)
+		}
+	})
+}

--- a/pkg/client/send_auth_test.go
+++ b/pkg/client/send_auth_test.go
@@ -348,7 +348,7 @@ func TestSendReports_Authentication(t *testing.T) {
 			setOAuthTestEnv(mockOAuthServer.URL, integrationClientID, integrationSecret, "")
 
 			// Run SendReports
-			err := SendReports(mockFernServer.URL, testProjectId, reportPassedPath, "auth-test", true)
+			err := SendReports(mockFernServer.URL, testProjectId, reportPassedPath, "auth-test", "", "", "", true)
 			if err != nil {
 				t.Fatalf("SendReports() with authentication failed: %v", err)
 			}
@@ -394,7 +394,7 @@ func TestSendReports_Authentication(t *testing.T) {
 			defer mockFernServer.Close()
 
 			// Run SendReports
-			err := SendReports(mockFernServer.URL, testProjectId, reportPassedPath, "no-auth-test", false)
+			err := SendReports(mockFernServer.URL, testProjectId, reportPassedPath, "no-auth-test", "", "", "", false)
 			if err != nil {
 				t.Fatalf("SendReports() without authentication failed: %v", err)
 			}

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -132,7 +132,7 @@ func TestGenerateStaticJsonFiles(t *testing.T) {
 		}))
 		defer mockFernReporter.Close()
 		// Run SendReports with input
-		if err := SendReports(mockFernReporter.URL, testProjectId, filePattern, exampleTags, true); err != nil {
+		if err := SendReports(mockFernReporter.URL, testProjectId, filePattern, exampleTags, "", "", "", true); err != nil {
 			panic(fmt.Errorf("failed to generate Fern test run JSON for '%s' test case (%s): %w", testCase, filePattern, err))
 		}
 	}

--- a/pkg/models/fern/types.go
+++ b/pkg/models/fern/types.go
@@ -10,6 +10,9 @@ type TestRun struct {
 	TestSeed      uint64     `json:"test_seed"`
 	StartTime     time.Time  `json:"start_time"`
 	EndTime       time.Time  `json:"end_time"`
+	GitBranch     string     `json:"git_branch,omitempty"`
+	GitSha        string     `json:"git_sha,omitempty"`
+	Environment   string     `json:"environment,omitempty"`
 	SuiteRuns     []SuiteRun `json:"suite_runs"`
 }
 


### PR DESCRIPTION
Closes #25. 

Adds optional `--branch`, `--commit`, and `--environment` flags (with `$GITHUB_*` / `$CI_*` env-var fallbacks) so test runs carry git provenance.