### PR TITLE
feat: add branch/commit/environment flags

### DIFF
--- a/cmd/send.go
+++ b/cmd/send.go
@@ -14,6 +14,9 @@ var (
 	projectId   string
 	filePattern string
 	tags        string
+	branch      string
+	commitSha   string
+	environment string
 )
 
 var sendCmd = &cobra.Command{
@@ -21,11 +24,36 @@ var sendCmd = &cobra.Command{
 	Short: "Send JUnit test reports to Fern",
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := client.SendReports(fernUrl, projectId, filePattern, tags, verbose); err != nil {
+		b, c, e := resolveProvenance(branch, commitSha, environment)
+		if err := client.SendReports(client.SendOptions{
+			FernURL: fernUrl, ProjectID: projectId, FilePattern: filePattern, Tags: tags,
+			Branch: b, CommitSha: c, Environment: e, Verbose: verbose,
+		}); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 			os.Exit(1)
 		}
 	},
+}
+
+// resolveProvenance fills in git provenance from common CI env vars when the
+// corresponding flag was not provided (an explicit flag value always wins).
+func resolveProvenance(branch, commit, environment string) (string, string, string) {
+	// GITHUB_HEAD_REF is the PR source branch (set only on pull_request events) and
+	// takes precedence over GITHUB_REF_NAME, which on PR builds is the synthetic
+	// refs/pull/<n>/merge ref rather than a real branch name.
+	return firstNonEmpty(branch, os.Getenv("GITHUB_HEAD_REF"), os.Getenv("GITHUB_REF_NAME"), os.Getenv("CI_COMMIT_REF_NAME")),
+		firstNonEmpty(commit, os.Getenv("GITHUB_SHA"), os.Getenv("CI_COMMIT_SHA")),
+		firstNonEmpty(environment, os.Getenv("CI_ENVIRONMENT_NAME"), os.Getenv("FERN_ENVIRONMENT"))
+}
+
+// firstNonEmpty returns the first non-empty string from the provided candidates.
+func firstNonEmpty(candidates ...string) string {
+	for _, s := range candidates {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 func init() {
@@ -33,6 +61,9 @@ func init() {
 	sendCmd.PersistentFlags().StringVarP(&projectId, "project-id", "p", "", "Id of the project to associate test reports with (required). You must register the application first in Fern Platform")
 	sendCmd.PersistentFlags().StringVarP(&filePattern, "file-pattern", "f", "", "file name pattern of test reports to send to Fern (required)")
 	sendCmd.PersistentFlags().StringVarP(&tags, "tags", "t", "", "comma-separated tags to be included on runs")
+	sendCmd.PersistentFlags().StringVar(&branch, "branch", "", "git branch name for this run (falls back to $GITHUB_HEAD_REF / $GITHUB_REF_NAME / $CI_COMMIT_REF_NAME)")
+	sendCmd.PersistentFlags().StringVar(&commitSha, "commit", "", "git commit SHA for this run (falls back to $GITHUB_SHA / $CI_COMMIT_SHA)")
+	sendCmd.PersistentFlags().StringVar(&environment, "environment", "", "environment label, e.g. ci, staging (falls back to $CI_ENVIRONMENT_NAME / $FERN_ENVIRONMENT)")
 	if err := sendCmd.MarkPersistentFlagRequired("fern-url"); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
 		os.Exit(1)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,19 +7,39 @@ import (
 	"github.com/guidewire-oss/fern-junit-client/pkg/util"
 )
 
-func SendReports(fernUrl, projectId, filePattern string, tags string, verbose bool) error {
+// SendOptions carries the parameters for SendReports as named fields, so callers
+// can't transpose the many same-typed string arguments by position. Branch,
+// CommitSha, and Environment are recorded as run provenance; leave them empty to
+// omit. Resolving them from CI env vars is the caller's concern (see cmd), which
+// keeps this client free of CI-provider specifics.
+type SendOptions struct {
+	FernURL     string
+	ProjectID   string
+	FilePattern string
+	Tags        string
+	Branch      string
+	CommitSha   string
+	Environment string
+	Verbose     bool
+}
+
+// SendReports parses JUnit XML reports and posts a TestRun to Fern Platform.
+func SendReports(opts SendOptions) error {
 	var testRun fern.TestRun
-	testRun.TestProjectID = projectId
+	testRun.TestProjectID = opts.ProjectID
 	testRun.TestSeed = uint64(util.GlobalClock.Now().Nanosecond())
+	testRun.GitBranch = opts.Branch
+	testRun.GitSha = opts.CommitSha
+	testRun.Environment = opts.Environment
 
 	log.Default().Println("Parsing reports...")
-	if err := parseReports(&testRun, filePattern, tags, verbose); err != nil {
+	if err := parseReports(&testRun, opts.FilePattern, opts.Tags, opts.Verbose); err != nil {
 		return err
 	}
 	log.Default().Println("Parsing reports succeeded!")
 
 	log.Default().Println("Sending reports to Fern...")
-	if err := sendTestRun(testRun, fernUrl, verbose); err != nil {
+	if err := sendTestRun(testRun, opts.FernURL, opts.Verbose); err != nil {
 		return err
 	}
 	log.Default().Println("Sending reports succeeded!")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -64,7 +64,7 @@ func TestSendReports(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := SendReports(tt.args.fernUrl, tt.args.projectId, tt.args.filePattern, tt.args.tags, tt.args.verbose); (err != nil) != tt.wantErr {
+			if err := SendReports(SendOptions{FernURL: tt.args.fernUrl, ProjectID: tt.args.projectId, FilePattern: tt.args.filePattern, Tags: tt.args.tags, Branch: "", CommitSha: "", Environment: "", Verbose: tt.args.verbose}); (err != nil) != tt.wantErr {
 				t.Errorf("SendReports() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/client/provenance_test.go
+++ b/pkg/client/provenance_test.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/guidewire-oss/fern-junit-client/pkg/models/fern"
+)
+
+// captureServer records the TestRun payload of the last request it receives.
+func captureServer(t *testing.T, got *fern.TestRun) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, got)
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// SendReports records the provenance it is given onto the payload (env-var
+// resolution is the caller's job — see cmd).
+func TestSendReportsRecordsProvenance(t *testing.T) {
+	var got fern.TestRun
+	srv := captureServer(t, &got)
+	defer srv.Close()
+
+	if err := SendReports(SendOptions{FernURL: srv.URL, ProjectID: testProjectId, FilePattern: reportPassedPath, Tags: exampleTags, Branch: "feature/x", CommitSha: "abc123", Environment: "staging", Verbose: false}); err != nil {
+		t.Fatalf("SendReports() error = %v", err)
+	}
+	if got.GitBranch != "feature/x" || got.GitSha != "abc123" || got.Environment != "staging" {
+		t.Errorf("payload provenance = {branch:%q sha:%q env:%q}, want {feature/x abc123 staging}",
+			got.GitBranch, got.GitSha, got.Environment)
+	}
+}

--- a/pkg/client/send_auth_test.go
+++ b/pkg/client/send_auth_test.go
@@ -348,7 +348,7 @@ func TestSendReports_Authentication(t *testing.T) {
 			setOAuthTestEnv(mockOAuthServer.URL, integrationClientID, integrationSecret, "")
 
 			// Run SendReports
-			err := SendReports(mockFernServer.URL, testProjectId, reportPassedPath, "auth-test", true)
+			err := SendReports(SendOptions{FernURL: mockFernServer.URL, ProjectID: testProjectId, FilePattern: reportPassedPath, Tags: "auth-test", Branch: "", CommitSha: "", Environment: "", Verbose: true})
 			if err != nil {
 				t.Fatalf("SendReports() with authentication failed: %v", err)
 			}
@@ -394,7 +394,7 @@ func TestSendReports_Authentication(t *testing.T) {
 			defer mockFernServer.Close()
 
 			// Run SendReports
-			err := SendReports(mockFernServer.URL, testProjectId, reportPassedPath, "no-auth-test", false)
+			err := SendReports(SendOptions{FernURL: mockFernServer.URL, ProjectID: testProjectId, FilePattern: reportPassedPath, Tags: "no-auth-test", Branch: "", CommitSha: "", Environment: "", Verbose: false})
 			if err != nil {
 				t.Fatalf("SendReports() without authentication failed: %v", err)
 			}

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -132,7 +132,7 @@ func TestGenerateStaticJsonFiles(t *testing.T) {
 		}))
 		defer mockFernReporter.Close()
 		// Run SendReports with input
-		if err := SendReports(mockFernReporter.URL, testProjectId, filePattern, exampleTags, true); err != nil {
+		if err := SendReports(SendOptions{FernURL: mockFernReporter.URL, ProjectID: testProjectId, FilePattern: filePattern, Tags: exampleTags, Branch: "", CommitSha: "", Environment: "", Verbose: true}); err != nil {
 			panic(fmt.Errorf("failed to generate Fern test run JSON for '%s' test case (%s): %w", testCase, filePattern, err))
 		}
 	}

--- a/pkg/models/fern/types.go
+++ b/pkg/models/fern/types.go
@@ -10,6 +10,9 @@ type TestRun struct {
 	TestSeed      uint64     `json:"test_seed"`
 	StartTime     time.Time  `json:"start_time"`
 	EndTime       time.Time  `json:"end_time"`
+	GitBranch     string     `json:"git_branch,omitempty"`
+	GitSha        string     `json:"git_sha,omitempty"`
+	Environment   string     `json:"environment,omitempty"`
 	SuiteRuns     []SuiteRun `json:"suite_runs"`
 }
 


### PR DESCRIPTION
Closes #25. 

Adds optional `--branch`, `--commit`, and `--environment` flags (with `$GITHUB_*` / `$CI_*` env-var fallbacks) so test runs carry git provenance.